### PR TITLE
Fix missing fmt argument in error message

### DIFF
--- a/ucelofka/src/translations.rs
+++ b/ucelofka/src/translations.rs
@@ -35,7 +35,7 @@ fn get_available_locales() -> Result<Vec<LanguageIdentifier>> {
 fn read_language_data(id: &LanguageIdentifier) -> Result<String> {
     let file = RESOURCES
         .get_file(format!("{}/ucelofka.ftl", id.to_string()))
-        .ok_or_else(|| anyhow!("{} translation not found",))?;
+        .ok_or_else(|| anyhow!("{} translation not found", id))?;
     Ok(from_utf8(file.contents)?.to_string())
 }
 


### PR DESCRIPTION
Without this, the error message would literally be "{} translation not found" with curly braces in it instead of the language id.